### PR TITLE
Changes view to use django.utils Timezone

### DIFF
--- a/alerts/views.py
+++ b/alerts/views.py
@@ -1,4 +1,5 @@
 import datetime
+from django.utils import timezone
 import os
 
 from smtplib import SMTPException
@@ -140,8 +141,8 @@ def update_event(page, url):
         date=page['date'],
         resale_active=page['resale_active']
     )
-
-    today = datetime.date.today()
+    
+    today = timezone.now().today().date()
     if (event.date - today).days < 0:
         event.delete()
         raise EventExpiredError()


### PR DESCRIPTION
Hi me and a few friends love using your site but we noticed that hours before the event had started we could not add a event to track. I think this should fix that issue.
Thanks!

Fixes update to use timezone.now() this will allow users to add their events regardless of location.