### PR TITLE
Reset ticket availability after sending

### DIFF
--- a/alerts/views.py
+++ b/alerts/views.py
@@ -180,6 +180,11 @@ def send(request):
             print(e)
             continue
 
+    # reset ticket availability to be updated later
+    for ticket in tickets:
+        ticket.available = False
+        ticket.save()
+
     return JsonResponse({
         'response': 'success',
         'sent': [


### PR DESCRIPTION
Related to #1 

Existing tickets may not be correctly linked to new trackers during `index()` (for instance, if the ticket names or prices have changed then `get_or_create()` will not get the old `Ticket`).

In that case, there are `Ticket`s in the db which do not get updated (until they are pruned).  Resetting the ticket availability after sending ensures the tickets don't get used again.